### PR TITLE
Move configuration access to classes

### DIFF
--- a/Magic8HeadService/Options/SpeechConfiguration.cs
+++ b/Magic8HeadService/Options/SpeechConfiguration.cs
@@ -1,0 +1,11 @@
+using Microsoft.Extensions.Configuration;
+
+namespace Magic8HeadService.Options;
+
+public class SpeechConfiguration
+{
+  [ConfigurationKeyName("Subscription")]
+  public string Subscription { get; set; }
+  [ConfigurationKeyName("Region")]
+  public string ServiceRegion { get; set; }
+}

--- a/Magic8HeadService/Options/TwitchBotCredentials.cs
+++ b/Magic8HeadService/Options/TwitchBotCredentials.cs
@@ -1,0 +1,17 @@
+using Microsoft.Extensions.Configuration;
+using TwitchLib.Client.Models;
+
+namespace Magic8HeadService.Options;
+
+public record TwitchBotCredentials
+{
+  [ConfigurationKeyName("UserName")] public string Username { get; set; }
+
+  [ConfigurationKeyName("ClientId")] public string ClientID { get; set; }
+  public string AccessToken { get; set; }
+ 
+  public ConnectionCredentials AsConnectionCredentials() => new ConnectionCredentials(this.Username, this.AccessToken);
+
+  public ConnectionCredentials AsConnectionCredentials(string websocketURI) => new ConnectionCredentials(this.Username, this.AccessToken, websocketURI);
+
+}

--- a/Magic8HeadService/Options/VoiceConfiguration.cs
+++ b/Magic8HeadService/Options/VoiceConfiguration.cs
@@ -1,0 +1,12 @@
+using Microsoft.Extensions.Configuration;
+
+namespace Magic8HeadService.Options;
+
+public record VoiceConfiguration
+{
+  [ConfigurationKeyName("Language")]
+  public string Language { get; set; }
+
+  [ConfigurationKeyName("VoiceName")]
+  public string VoiceName { get; set; }
+}

--- a/Magic8HeadService/Program.cs
+++ b/Magic8HeadService/Program.cs
@@ -4,87 +4,114 @@ using Microsoft.Extensions.Hosting;
 using MrBigHead.Services;
 using Scrutor;
 using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Options;
 using TwitchLib.Api;
 using TwitchLib.Api.Core;
 using TwitchLib.Api.Core.Interfaces;
 using TwitchLib.Client;
+using TwitchLib.Client.Events;
 using TwitchLib.Client.Models;
 using TwitchLib.Communication.Clients;
 using TwitchLib.Communication.Models;
+using Magic8HeadService.Options;
 
 namespace Magic8HeadService
 {
-    public class Program
+  public class Program
+  {
+
+    public static void Main(string[] args)
     {
-
-        public static void Main(string[] args)
-        {
-            var host = CreateHostBuilder(args).Build();
-            host.Run();
-        }
-
-        public static IHostBuilder CreateHostBuilder(string[] args) =>
-            Host.CreateDefaultBuilder(args)
-                .UseSystemd()
-                .ConfigureAppConfiguration((hostContext, builder) =>
-                {
-                    // Yes, we are using this in production as well.  
-                    // we will change this eventually
-                    builder.AddUserSecrets<Program>(optional: true);
-                })
-                .ConfigureServices((hostContext, services) =>
-                {
-                    
-                    var configuration = services.BuildServiceProvider().GetService<IConfiguration>();
-
-                    // need to add a command here to validate and report on missing configuration entries
-                    var userName = configuration["TwitchBotConfiguration:UserName"];
-                    var clientId = configuration["TwitchBotConfiguration:ClientId"];
-                    var accessToken = configuration["TwitchBotConfiguration:AccessToken"];
-                    var refreshToken = configuration["TwitchBotconfiguration:RefreshToken"];
-                    var credentials = new ConnectionCredentials(userName, accessToken);
-
-                    services.AddSingleton(credentials);
-
-                    services.AddSingleton(new ClientOptions
-                        {
-                            DisconnectWait = 5000,
-                            MessagesAllowedInPeriod = 750,
-                            ReconnectionPolicy = new ReconnectionPolicy(3000, maxAttempts: 50),
-                            ThrottlingPeriod = TimeSpan.FromSeconds(30),
-                            UseSsl = true
-                        });
-
-                    services.AddSingleton<WebSocketClient>();
-                    services.AddSingleton<TwitchClient>();
-
-                    // Setup access to the API and register it.
-                    services.AddSingleton<IApiSettings>(new ApiSettings
-                        { 
-                            ClientId = clientId,
-                            AccessToken = accessToken
-                        });
-
-                    services.AddSingleton<TwitchAPI>();
-
-                    services.AddHttpClient();
-
-                    // adding the ICommandMbhToTwitch main series of commands
-                    services.Scan(scan => scan
-                        .FromAssemblyOf<ICommandMbhToTwitch>()
-                            .AddClasses(classes => classes.AssignableTo<ICommandMbhToTwitch>())
-                                .AsImplementedInterfaces()
-                                .WithTransientLifetime());
-
-                    services.AddScoped<ISayingService, SayingService>();
-                    services.AddScoped<ISayingResponse, SayingResponse>();
-                    services.AddScoped<IDadJokeService, DadJokeService>();
-                    services.AddScoped<ICommandMbhTwitchHelp, HelpCommandReal>();
-
-                    services.AddHostedService<Worker>();
-
-                    Console.WriteLine($"services has a count: {services.Count}");
-                });
+      var host = CreateHostBuilder(args).Build();
+      host.Run();
     }
+
+
+    public static IHostBuilder CreateHostBuilder(string[] args) =>
+      Host.CreateDefaultBuilder(args)
+        .UseSystemd()
+        .ConfigureAppConfiguration((hostContext, builder) =>
+        {
+          // Yes, we are using this in production as well.  
+          // we will change this eventually
+          builder.AddUserSecrets<Program>(optional: true);
+        })
+        .ConfigureServices((hostContext, services) =>
+        {
+          services.Configure<TwitchBotCredentials>(hostContext.Configuration.GetSection("TwitchBotConfiguration"));
+          services.Configure<SpeechConfiguration>(hostContext.Configuration.GetSection("SpeechService"));
+          services.Configure<VoiceConfiguration>(hostContext.Configuration.GetSection("Voice"));
+
+          services.AddSingleton<ConnectionCredentials>((svc) =>
+          {
+            var val = svc.CreateScope().ServiceProvider.GetRequiredService<IOptionsSnapshot<TwitchBotCredentials>>().Value.AsConnectionCredentials();
+
+            return val;
+          });
+
+
+          services.AddSingleton<ClientOptions>( svc =>
+          {
+            var clientOption = new ClientOptions{
+            DisconnectWait = 5000,
+            MessagesAllowedInPeriod = 750,
+            ReconnectionPolicy = new ReconnectionPolicy(3000, maxAttempts: 50),
+            ThrottlingPeriod = TimeSpan.FromSeconds(30),
+            UseSsl = true};
+
+            return clientOption;
+          });
+
+          services.AddSingleton<WebSocketClient>();
+          services.AddSingleton<TwitchClient>();
+
+          services.AddOptions<List<string>>("CommandNames").Configure<IServiceProvider>((str, svc) =>
+          {
+
+            var commandNames = svc.GetServices<ICommandMbhToTwitch>()
+//              .Where(x => x.GetType() == typeof())
+              .Select(cmd => cmd.Name);
+            str.AddRange(commandNames);
+          });
+
+
+          services.AddSingleton<IApiSettings>(provider =>
+          {
+            var credentials = provider.CreateScope().ServiceProvider.GetRequiredService<IOptionsSnapshot<TwitchBotCredentials>>().Value;
+            return new ApiSettings
+            {
+              ClientId = credentials.ClientID,
+              AccessToken = credentials.AccessToken,
+            };
+          });
+
+          services.AddSingleton<TwitchAPI>();
+
+          services.AddHttpClient();
+
+          // adding the ICommandMbhToTwitch main series of commands
+          services.Scan(scan => scan
+            .FromAssemblyOf<ICommandMbhToTwitch>()
+            .AddClasses(classes => classes.AssignableTo<ICommandMbhToTwitch>())
+            .AsImplementedInterfaces()
+            .WithTransientLifetime());
+
+          services.AddScoped<ISayingService, SayingService>();
+          services.AddScoped<ISayingResponse, SayingResponse>();
+          services.AddScoped<IDadJokeService, DadJokeService>();
+          services.AddScoped<ICommandMbhTwitchHelp, HelpCommandReal>();
+
+          services.AddHostedService<Worker>();
+
+          Console.WriteLine($"services has a count: {services.Count}");
+        })
+      
+      
+      ;
+  }
+
 }

--- a/Magic8HeadService/SayingResponse.cs
+++ b/Magic8HeadService/SayingResponse.cs
@@ -7,98 +7,106 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Options;
+using Magic8HeadService.Options;
 
 namespace Magic8HeadService
 {
-    public class SayingResponse : ISayingResponse
+  public class SayingResponse : ISayingResponse
+  {
+    private Random random;
+    private IConfiguration configuration;
+    private readonly ISayingService sayingsService;
+    private readonly ILogger<Worker> logger;
+    private IList<Saying> sayings;
+    private readonly SpeechSynthesizer speechSynthesizer;
+
+    private IOptionsSnapshot<SpeechConfiguration> SpeechConfiguration { get; set; }
+    private IOptionsSnapshot<VoiceConfiguration> VoiceConfiguration { get; set; }
+
+
+    public SayingResponse(IOptionsSnapshot<SpeechConfiguration> speechConfiguration,
+      IOptionsSnapshot<VoiceConfiguration> voiceConfiguration, IConfiguration configuration,
+      ISayingService sayingsService, ILogger<Worker> logger)
     {
-        private Random random;
-        private IConfiguration config;
-        private readonly ISayingService sayingsService;
-        private readonly ILogger<Worker> logger;
-        private IList<Saying> sayings;
-        private readonly SpeechSynthesizer speechSynthesizer;
+      this.configuration = configuration;
+      this.sayingsService = sayingsService;
+      this.logger = logger;
+      this.SpeechConfiguration = speechConfiguration;
+      this.VoiceConfiguration = voiceConfiguration;
 
-        public SayingResponse(IConfiguration config, ISayingService sayingsService, ILogger<Worker> logger)
-        {
-            this.config = config;
-            this.sayingsService = sayingsService;
-            this.logger = logger;
+      // create a new speech synth
+      var speechConfig = SpeechConfig
+        .FromSubscription(this.SpeechConfiguration.Value.Subscription, this.SpeechConfiguration.Value.ServiceRegion);
+      speechConfig.SpeechSynthesisLanguage = this.VoiceConfiguration.Value.Language;
+      speechConfig.SpeechSynthesisVoiceName = this.VoiceConfiguration.Value.VoiceName;
+      logger.LogInformation($"Here is the SpeechSynthesisLanguage: {speechConfig.SpeechSynthesisLanguage}");
+      logger.LogInformation($"Here is the SpeechSynthesisVoiceName: {speechConfig.SpeechSynthesisVoiceName}");
 
-            var speechSubscription = config["TwitchBotConfiguration:SpeechSubscription"];
+      speechSynthesizer = new SpeechSynthesizer(speechConfig);
 
-            var speechServiceRegion = config["TwitchBotConfiguration:SpeechServiceRegion"];
-            // create a new speech synth
-            var speechConfig = SpeechConfig
-                .FromSubscription(config["TwitchBotConfiguration:SpeechSubscription"], config["TwitchBotConfiguration:SpeechServiceRegion"]);
-            speechConfig.SpeechSynthesisLanguage = "en-GB";
-            speechConfig.SpeechSynthesisVoiceName = "en-GB-RyanNeural";
-            logger.LogInformation($"Here is the SpeechSynthesisLanguage: {speechConfig.SpeechSynthesisLanguage}");
-            logger.LogInformation($"Here is the SpeechSynthesisVoiceName: {speechConfig.SpeechSynthesisVoiceName}");
-
-            speechSynthesizer = new SpeechSynthesizer(speechConfig);
-
-            SetupSayingsAsync().Wait();
-        }
-
-        public async Task SetupSayingsAsync()
-        {
-            logger.LogInformation("Setiing up Sayings...");
-
-            random = new Random();
-            sayings = await sayingsService.GetAllSayingsAsync();
-
-            logger.LogInformation($"saying count: {sayings.Count}");
-        }
-
-        public async Task SaySomethingNice(string message)
-        {
-            logger.LogInformation($"Saying: {message}");
-
-            using (var result = await speechSynthesizer.SpeakTextAsync(message))
-            {
-                if (result.Reason == ResultReason.SynthesizingAudioCompleted)
-                {
-                    logger.LogInformation($"Speech synthesized to speaker for text [{message}]");
-                }
-                else if (result.Reason == ResultReason.Canceled)
-                {
-                    var cancellation = SpeechSynthesisCancellationDetails.FromResult(result);
-                    logger.LogInformation($"CANCELED: Reason={cancellation.Reason}");
-
-                    if (cancellation.Reason == CancellationReason.Error)
-                    {
-                        logger.LogError($"CANCELED: ErrorCode={cancellation.ErrorCode}");
-                        logger.LogError($"CANCELED: ErrorDetails=[{cancellation.ErrorDetails}]");
-                        logger.LogError($"CANCELED: Did you update the subscription info?");
-                    }
-                }
-            }
-            return;
-        }
-
-        public string PickSaying()
-        {
-            return PickSaying(Moods.Snarky);
-        }
-
-        public string PickSaying(string mood)
-        {
-            logger.LogInformation("PickSaying: ");
-
-            var currentSelectedSayings = sayings.Select(p => p)
-                .Where(m => m.Mood == mood)
-                .ToArray();
-
-            if (currentSelectedSayings.Length == 0)
-                return string.Empty;
-
-            var index = random.Next(currentSelectedSayings.Length);
-
-            logger.LogInformation($"PickSaying: count: {currentSelectedSayings.Length}, random: {index}");
-            var pickedSaying = currentSelectedSayings[index];
-
-            return pickedSaying.Phrase;
-        }
+      SetupSayingsAsync().Wait();
     }
+
+    public async Task SetupSayingsAsync()
+    {
+      logger.LogInformation("Setiing up Sayings...");
+
+      random = new Random();
+      sayings = await sayingsService.GetAllSayingsAsync();
+
+      logger.LogInformation($"saying count: {sayings.Count}");
+    }
+
+    public async Task SaySomethingNice(string message)
+    {
+      logger.LogInformation($"Saying: {message}");
+
+      using (var result = await speechSynthesizer.SpeakTextAsync(message))
+      {
+        if (result.Reason == ResultReason.SynthesizingAudioCompleted)
+        {
+          logger.LogInformation($"Speech synthesized to speaker for text [{message}]");
+        }
+        else if (result.Reason == ResultReason.Canceled)
+        {
+          var cancellation = SpeechSynthesisCancellationDetails.FromResult(result);
+          logger.LogInformation($"CANCELED: Reason={cancellation.Reason}");
+
+          if (cancellation.Reason == CancellationReason.Error)
+          {
+            logger.LogError($"CANCELED: ErrorCode={cancellation.ErrorCode}");
+            logger.LogError($"CANCELED: ErrorDetails=[{cancellation.ErrorDetails}]");
+            logger.LogError($"CANCELED: Did you update the subscription info?");
+          }
+        }
+      }
+
+      return;
+    }
+
+    public string PickSaying()
+    {
+      return PickSaying(Moods.Snarky);
+    }
+
+    public string PickSaying(string mood)
+    {
+      logger.LogInformation("PickSaying: ");
+
+      var currentSelectedSayings = sayings.Select(p => p)
+        .Where(m => m.Mood.Equals(mood, StringComparison.OrdinalIgnoreCase))
+        .ToArray();
+
+      if (currentSelectedSayings.Length == 0)
+        return string.Empty;
+
+      var index = random.Next(currentSelectedSayings.Length);
+
+      logger.LogInformation($"PickSaying: count: {currentSelectedSayings.Length}, random: {index}");
+      var pickedSaying = currentSelectedSayings[index];
+
+      return pickedSaying.Phrase;
+    }
+  }
 }

--- a/Magic8HeadService/TwitchBot.cs
+++ b/Magic8HeadService/TwitchBot.cs
@@ -1,5 +1,4 @@
 using Microsoft.Extensions.Logging;
-using MrBigHead.Shared;
 using System;
 using System.Linq;
 using System.Collections.Generic;

--- a/Magic8HeadService/TwitchBotConfiguration.cs
+++ b/Magic8HeadService/TwitchBotConfiguration.cs
@@ -1,8 +1,0 @@
-namespace Magic8HeadService
-{
-    public class TwitchBotConfiguration
-    {
-        public string UserName { get; set; }
-        public string AccessToken { get; set; }
-    }
-}

--- a/Magic8HeadService/Worker.cs
+++ b/Magic8HeadService/Worker.cs
@@ -16,7 +16,7 @@ namespace Magic8HeadService
     {
         private readonly ILogger<Worker> logger;
         private readonly IServiceProvider service;
-        public readonly IConfiguration config;
+        public readonly IConfiguration Configuration;
 
         readonly int buttonPin = 7;
         GpioController controller;
@@ -25,17 +25,14 @@ namespace Magic8HeadService
         readonly ISayingResponse scopedSayingResponse;
         readonly IDadJokeService scopedDadJokeService;
 
-        public Worker(IServiceProvider service, IConfiguration config, ILogger<Worker> logger)
+        public Worker(IServiceProvider service, IConfiguration configuration, ILogger<Worker> logger)
         {
             this.logger = logger;
             this.service = service;
-            this.config = config;
+            this.Configuration = configuration;
 
-            var defaultLogLevel = config["Logging:LogLevel:Default"];
+            var defaultLogLevel = this.Configuration["Logging:LogLevel:Default"];
             logger.LogInformation($"defaultLogLevel = {defaultLogLevel}");
-
-            var userName = config["TwitchBotConfiguration:UserName"];
-            var accessToken = config["TwitchBotConfiguration:AccessToken"];
 
             using var scope = service.CreateScope();
 
@@ -56,7 +53,7 @@ namespace Magic8HeadService
             var helpCommand = scope.ServiceProvider.GetService<ICommandMbhTwitchHelp>();
 
             var twitchBot = new TwitchBot(twitchClient, connectionCredentials, "haroldpulcher",
-                 config, scopedSayingResponse, scopedDadJokeService,
+                 this.Configuration, scopedSayingResponse, scopedDadJokeService,
                 listOfCommands, helpCommand, logger);
 
             SetupGPIO();

--- a/Magic8HeadService/appsettings.json
+++ b/Magic8HeadService/appsettings.json
@@ -5,5 +5,20 @@
       "Microsoft": "Warning",
       "Microsoft.Hosting.Lifetime": "Information"
     }
+  },
+  "TwitchBotConfiguration": {
+    "UserName": "Username",
+    "ClientId": "TwitchClientID",
+    "AccessToken": "TwitchAccessToken",
+    "RefreshToken": "TwitchRefreshToken"
+  },
+  "SpeechService": {
+    "Subscription": "SpeechSubscription",
+    "Region": "SpeechRegion"
+  },
+  "Voice": {
+    "Language": "en-GB",
+    "VoiceName": "en-GB-RyanNeural"
   }
+
 }


### PR DESCRIPTION
- Remove direct access to IConfiguration object when possible
- Configure objects which depended on IConfiguration access into DI without creating an instance
- Create configuration classes for the various services needing one
- Add configuration elements with empty/descriptive (but invalid) values to appsettings.json